### PR TITLE
A number of improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM alpine:3.4
 MAINTAINER Jeroen Geusebroek <me@jeroengeusebroek.nl>
 
 ENV PACKAGE_LIST="lighttpd lighttpd-mod_webdav lighttpd-mod_auth" \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Docker WebDAV image
 
-A tiny image running [gliderlabs/docker-alpine](https://github.com/gliderlabs/docker-alpine) Linux and [Lighttpd](https://www.lighttpd.net/).
+A tiny image running the official [alpine](https://hub.docker.com/_/alpine/)
+Linux and [Lighttpd](https://www.lighttpd.net/).
 
 ## Usage
 
@@ -13,23 +14,36 @@ A tiny image running [gliderlabs/docker-alpine](https://github.com/gliderlabs/do
 		-v /<host_directory_to_share>:/webdav \
 		jgeusebroek/webdav
 
-By default the WebDAV server is password protected with user `webdav` and password `davbew` which obviously isn't really secure.
-This can easily be overwritten, by creating a `config directory` on the host with an *htpasswd* file and mounting this as a volume on `/config`.
+By default the WebDAV server is password protected with user `webdav` and
+password `davbew` which obviously isn't really secure.
+This can easily be overwritten, by creating a `config directory` on the host
+with an *htpasswd* file and mounting this as a volume on `/config`.
 
 	-v /<host_config_directory>:/config
 
-You could use an online htpasswd generator like [https://www.transip.nl/htpasswd/](https://www.transip.nl/htpasswd/) to create the password hashes when you don't have a machine with the `htpasswd` package. (**Hint**: The package is `apache2-utils`)
+You could use an online htpasswd generator like
+[https://www.transip.nl/htpasswd/](https://www.transip.nl/htpasswd/) to create
+the password hashes when you don't have a machine with the `htpasswd` package.
+(**Hint**: The package is `apache2-utils`)
 
-You can also provide a list of IP's in the form of a regular expression which are then whitelisted. See below.
+You can also provide a list of IP's in the form of a regular expression which
+are then whitelisted. Whitelisted IP addresses will not need to enter
+credentials to access the storage.
+
+Lighttpd runs in the foreground in this image, and access and error logs are
+rerouted so they can be capture by the regular Docker logging facilities.
 
 ## Optional environment variables
 
 * `USER_UID` User ID of the lighttpd daemon account (default: 2222).
 * `USER_GID` Group ID of the lighttpd daemon account (default: 2222).
 * `WHITELIST` Regexp for a list of IP's (default: none). Example: `-e WHITELIST='192.168.1.*|172.16.1.2'`
-* `READWRITE` When this is set to `true`, the WebDAV share can be written to (default: False). Example: `-e READWRITE=true`
+* `READWRITE` When this is set to `true`, the WebDAV share can be written to (default: false). Example: `-e READWRITE=true`
+* `OWNERSHIP` When this is set to `true`, ownership of the `/webdav` data directory is forced to the user and group.  This is necessary if you want to be able to write to the directory, and is probably safe when mounting volumes.
 
-**IMPORTANT**: Should you use a persistent config volume, the WHITELIST and READWRITE variables will only have effect the first time. I.e., when you don't have a (custom) configuration yet.
+**IMPORTANT**: Should you use a persistent config volume, the WHITELIST and
+READWRITE variables will only have effect the first time. I.e., when you don't
+have a (custom) configuration yet.
 
 ## License
 
@@ -38,3 +52,4 @@ MIT / BSD
 ## Author Information
 
 [Jeroen Geusebroek](http://jeroengeusebroek.nl/)
+[Emmanuel Frecon](https://github.com/efrecon/)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,31 +10,47 @@ READWRITE=${READWRITE:=false}
 
 # Add user if it does not exist
 if ! id -u "${USERNAME}" >/dev/null 2>&1; then
-	addgroup -g ${USER_GID:=2222} ${GROUP}
-	adduser -G ${GROUP} -D -H -u ${USER_UID:=2222} ${USERNAME}
+    addgroup -g ${USER_GID:=2222} ${GROUP}
+    adduser -G ${GROUP} -D -H -u ${USER_UID:=2222} ${USERNAME}
 fi
 
 chown webdav /var/log/lighttpd
 
+# Force the /webdav directory to be owned by webdav/webdav otherwise we won't be
+# able to write to it. This is ok if you mount from volumes, perhaps less if you
+# mount from the host, so do this conditionally.
+OWNERSHIP=${OWNERSHIP:=false}
+if [ "$OWNERSHIP" -eq "true" ]; then
+    chown -R webdav /webdav
+    chgrp -R webdav /webdav
+fi
+
+# Setup whitelisting addresses. Adresses that are whitelisted will not need to
+# enter credentials to access the webdav storage.
 if [ -n "$WHITELIST" ]; then
-	sed -i "s/WHITELIST/${WHITELIST}/" /etc/lighttpd/webdav.conf
+    sed -i "s/WHITELIST/${WHITELIST}/" /etc/lighttpd/webdav.conf
 fi
 
+# Reflect the value of READWRITE into the lighttpd configuration
+# webdav.is-readonly. Do this at all times, no matters what was in the file (so
+# that THIS shell decides upon the R/W status and nothing else.)
 if [ "$READWRITE" = true ]; then
-	sed -i "s/readonly = \"disable\"/readonly = \"enable\"/" /etc/lighttpd/webdav.conf
+    sed -i "s/is-readonly = \"\\w*\"/is-readonly = \"disable\"/" /etc/lighttpd/webdav.conf
+else
+    sed -i "s/is-readonly = \"\\w*\"/is-readonly = \"enable\"/" /etc/lighttpd/webdav.conf
 fi
 
+# Copy good default configuration files if we had none.
 if [ ! -f /config/htpasswd ]; then
-	cp /etc/lighttpd/htpasswd /config/htpasswd
+    cp /etc/lighttpd/htpasswd /config/htpasswd
 fi
 
 if [ ! -f /config/webdav.conf ]; then
-	cp /etc/lighttpd/webdav.conf /config/webdav.conf
+    cp /etc/lighttpd/webdav.conf /config/webdav.conf
 fi
 
-lighttpd -f /etc/lighttpd/lighttpd.conf
-
-# Hang on a bit while the server starts
-sleep 5
-
-tail -f /var/log/lighttpd/*.log
+# Run in foreground, see: https://redmine.lighttpd.net/issues/2731
+mkfifo -m 600 /tmp/lighttpd.log
+cat <> /tmp/lighttpd.log 1>&2 &
+chown webdav /tmp/lighttpd.log
+lighttpd -D -f /etc/lighttpd/lighttpd.conf 2>&1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ chown webdav /var/log/lighttpd
 # able to write to it. This is ok if you mount from volumes, perhaps less if you
 # mount from the host, so do this conditionally.
 OWNERSHIP=${OWNERSHIP:=false}
-if [ "$OWNERSHIP" -eq "true" ]; then
+if [ "$OWNERSHIP" == "true" ]; then
     chown -R webdav /webdav
     chgrp -R webdav /webdav
 fi
@@ -34,7 +34,7 @@ fi
 # Reflect the value of READWRITE into the lighttpd configuration
 # webdav.is-readonly. Do this at all times, no matters what was in the file (so
 # that THIS shell decides upon the R/W status and nothing else.)
-if [ "$READWRITE" = true ]; then
+if [ "$READWRITE" == "true" ]; then
     sed -i "s/is-readonly = \"\\w*\"/is-readonly = \"disable\"/" /etc/lighttpd/webdav.conf
 else
     sed -i "s/is-readonly = \"\\w*\"/is-readonly = \"enable\"/" /etc/lighttpd/webdav.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,10 @@ fi
 
 chown webdav /var/log/lighttpd
 
+# Create directory to hold locks
+mkdir /locks
+chown ${USERNAME}:${GROUP} /locks
+
 # Force the /webdav directory to be owned by webdav/webdav otherwise we won't be
 # able to write to it. This is ok if you mount from volumes, perhaps less if you
 # mount from the host, so do this conditionally.

--- a/files/lighttpd.conf
+++ b/files/lighttpd.conf
@@ -14,8 +14,11 @@ server.document-root  = "/webdav"
 server.pid-file       = "/run/lighttpd.pid"
 server.follow-symlink = "enable"
 
-var.logdir            = "/var/log/lighttpd"
-accesslog.filename    = var.logdir + "/access.log"
-server.errorlog       = var.logdir  + "/error.log"
+# No errorlog specification to keep the default (stderr) and make sure lighttpd
+# does not try closing/reopening. And redirect all access logs to a pipe. See
+# https://redmine.lighttpd.net/issues/2731 for details
+accesslog.filename    = "/tmp/lighttpd.log"
+#Omitting the following on purpose
+#server.errorlog       = "/dev/stderr"
 
 include "/config/webdav.conf"

--- a/files/webdav.conf
+++ b/files/webdav.conf
@@ -6,6 +6,7 @@ $HTTP["remoteip"] !~ "WHITELIST" {
 
     webdav.activate = "enable"
     webdav.is-readonly = "disable"
+    webdav.sqlite-db-name = "/locks/lighttpd.webdav_lock.db" 
 
     auth.backend = "htpasswd"
     auth.backend.htpasswd.userfile = "/config/htpasswd"
@@ -23,6 +24,7 @@ else $HTTP["remoteip"] =~ "WHITELIST" {
 
     webdav.activate = "enable"
     webdav.is-readonly = "disable"
+    webdav.sqlite-db-name = "/locks/lighttpd.webdav_lock.db" 
   }
 
 }


### PR DESCRIPTION
I have modified this image so that it:
- is based on the latest official Alpine (instead of gliderlabs)
- fixes proper semantics on `READWRITE` (the logic was broken)
- forces webdav/webdav ownership of the `/webdav` directory so that writing properly works (on demand)
- runs `lighttpd` in the foreground, and arranges to output all logs to stdout for rerouting into Docker.

All changes are documented and I would suggest to bring them in.
