### PR TITLE
Fixed foregrounding of the daemon 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ rerouted so they can be capture by the regular Docker logging facilities.
 
 ## Optional environment variables
 
+* `USERNAME` usename of the lighttpd daemon account (default: webdav).
+* `GROUP` group name of the lighttpd daemon account (default: webdav).
 * `USER_UID` User ID of the lighttpd daemon account (default: 2222).
 * `USER_GID` Group ID of the lighttpd daemon account (default: 2222).
 * `WHITELIST` Regexp for a list of IP's (default: none). Example: `-e WHITELIST='192.168.1.*|172.16.1.2'`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,11 @@ fi
 # Only allow read access by default
 READWRITE=${READWRITE:=false}
 
-# Add user if it does not exist
-if ! id -u "${USERNAME}" >/dev/null 2>&1; then
+# Add user and group if they do not exist
+if ! getent group "${GROUP}" >/dev/null 2>&1; then
     addgroup -g ${USER_GID:=2222} ${GROUP}
+fi
+if ! id -u "${USERNAME}" >/dev/null 2>&1; then
     adduser -G ${GROUP} -D -H -u ${USER_UID:=2222} ${USERNAME}
 fi
 


### PR DESCRIPTION
This fixes so that daemon really goes into the foreground (through calling exec as the last line of the wrapping shell script).  Also, the name of the user and group are now variables that can be set from the outside.
